### PR TITLE
Move to multistage and shrink final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM golang:stretch as build
 COPY . /src
 WORKDIR /src
 RUN go get -d -v ./...
-RUN go install -v ./...
+# RUN go install -v ./...
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o /src/BurpSuiteTeamServer cmd/BurpSuiteTeamServer/BurpSuiteTeamServer.go
 
+FROM scratch
+COPY --from=build /src/BurpSuiteTeamServer /BurpSuiteTeamServer
 EXPOSE 8989
-CMD ["BurpSuiteTeamServer"]
+ENTRYPOINT ["/BurpSuiteTeamServer"]


### PR DESCRIPTION
By statically linking the binary and using the Scratch image you can siginificantly reduce the docker image produced by this build.