### PR TITLE
complete redesign of the server code

### DIFF
--- a/internal/BurpTCMessage.go
+++ b/internal/BurpTCMessage.go
@@ -49,7 +49,6 @@ type BurpRequestResponse struct {
 
 type BurpTCMessage struct {
 	BurpRequestResponse *BurpRequestResponse `json:"burpmsg"`
-	MessageTarget       string               `json:"messageTarget"`
 	MessageType         string               `json:"msgtype"`
 	Data                string               `json:"data"`
 }
@@ -59,8 +58,8 @@ func NewBurpTCMessage() *BurpTCMessage {
 }
 
 func (b BurpTCMessage) String() string {
-	return fmt.Sprintf("%+v - %s - %s - %s",
-		b.BurpRequestResponse, b.MessageTarget, b.MessageType, b.Data)
+	return fmt.Sprintf("%+v - %s - %s",
+		b.BurpRequestResponse, b.MessageType, b.Data)
 }
 
 func (b BurpRequestResponse) addComment(comment Comment) {

--- a/internal/Client.go
+++ b/internal/Client.go
@@ -4,22 +4,17 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"github.com/fasthttp/websocket"
 	"log"
-	"reflect"
-	"strconv"
-	"strings"
 	"time"
 )
 
 type Client struct {
 	conn         *websocket.Conn
-	roomName     string
-	sendChannel  chan Message
+	room         string
+	sendChannel  chan *Message
 	mutedClients []string
 	name         string
-	serverHub    *ServerHub
 }
 
 func (c *Client) isGivenClientMuted(clientName string) bool {
@@ -31,180 +26,20 @@ func (c *Client) isGivenClientMuted(clientName string) bool {
 	return false
 }
 
-func (c *Client) parseMessage(message *BurpTCMessage) error {
-	//log.Printf("Got message: %+v from client: %s\n",*message,c.name)
-	switch message.MessageType {
-	case "SYNC_SCOPE_MESSAGE":
-		if message.MessageTarget != "Self" {
-			log.Printf("received new scope from %s", c.name)
-			c.serverHub.rooms[c.roomName].scope = message.Data
-		} else {
-			log.Printf("%s requesting scope", c.name)
-			message.Data = c.serverHub.rooms[c.roomName].scope
-		}
-		c.serverHub.messages <- generateMessage(message, c, c.roomName, message.MessageTarget)
-	case "JOIN_ROOM_MESSAGE":
-		if len(c.serverHub.rooms[message.MessageTarget].password) > 0 {
-			if c.serverHub.rooms[message.MessageTarget].password == message.Data {
-				log.Printf("%s joining room: %s", c.name, message.MessageTarget)
-				c.serverHub.rooms[c.roomName].deleteClient(c.name)
-				c.serverHub.rooms[message.MessageTarget].addClient(c)
-				c.serverHub.rooms[c.roomName].sendRoomMessagesToNewRoomMember(c.name)
-				message.MessageType = "GOOD_PASSWORD_MESSAGE"
-				c.serverHub.messages <- generateMessage(message, c, c.roomName, "Self")
-			} else {
-				//bad password
-				message.MessageType = "BAD_PASSWORD_MESSAGE"
-				c.serverHub.messages <- generateMessage(message, c, c.roomName, "Self")
-			}
-
-		} else {
-			log.Printf("%s joining room: %s", c.name, message.MessageTarget)
-			c.serverHub.rooms[c.roomName].deleteClient(c.name)
-			c.serverHub.rooms[message.MessageTarget].addClient(c)
-			c.serverHub.rooms[c.roomName].sendRoomMessagesToNewRoomMember(c.name)
-
-		}
-	case "LEAVE_ROOM_MESSAGE":
-		log.Printf("%s leaving room: %s", c.name, c.roomName)
-		c.serverHub.rooms[c.roomName].deleteClient(c.name)
-		if len(c.serverHub.rooms[c.roomName].clients) == 0 {
-			c.serverHub.deleteRoom(c.roomName)
-		}
-		c.serverHub.rooms["server"].addClient(c)
-	case "ADD_ROOM_MESSAGE":
-		log.Printf("creating new room: " + message.MessageTarget)
-		c.serverHub.rooms[c.roomName].deleteClient(c.name)
-		c.serverHub.addRoom(message.Data, message.MessageTarget)
-		c.serverHub.rooms[message.MessageTarget].addClient(c)
-	case "MUTE_MESSAGE":
-		if message.MessageTarget == "All" {
-			keys := reflect.ValueOf(c.serverHub.rooms[c.roomName].clients).MapKeys()
-			log.Printf("Clients to mute %s", keys)
-			for i := 0; i < len(keys); i++ {
-				key := keys[i].String()
-				if key != c.name {
-					c.mutedClients = append(c.mutedClients, key)
-				}
-			}
-		} else {
-			log.Printf("Client to mute %s", message.MessageTarget)
-			c.mutedClients = append(c.mutedClients, message.MessageTarget)
-		}
-		log.Printf("%s muted these clients %s", c.name, c.mutedClients)
-	case "UNMUTE_MESSAGE":
-		if message.MessageTarget == "All" {
-			keys := reflect.ValueOf(c.serverHub.rooms[c.roomName].clients).MapKeys()
-			for i := 0; i < len(keys); i++ {
-				key := keys[i].String()
-				if key != c.name {
-					c.mutedClients = remove(c.mutedClients, index(c.mutedClients, keys[i].String()))
-				}
-			}
-		} else {
-			c.mutedClients = remove(c.mutedClients, index(c.mutedClients, message.MessageTarget))
-		}
-		log.Printf("%s unmuted %s", c.name, message.MessageTarget)
-	case "GET_ROOMS_MESSAGE":
-		rooms := c.serverHub.rooms
-		keys := make([]string, 0, len(rooms))
-		for k := range rooms {
-			if k != "server" {
-				keys = append(keys, k+"::"+strconv.FormatBool(len(rooms[k].password) > 0))
-			}
-		}
-		message.Data = strings.Join(keys, ",")
-		//log.Printf("Rooms message: %+v\n",message)
-		c.serverHub.messages <- generateMessage(message, c, c.roomName, message.MessageTarget)
-	//case "COMMENT_MESSAGE": NOT CONVINCED THIS IS ALL THAT USEFUL, MAY REVISIT
-	//
-	//	//If there are already comments in the room
-	//	if len(c.serverHub.rooms[c.roomName].comments.getRequestWithComments(message.Data).Comments) > 0 {
-	//		//If the incoming request with comments has less comments than the old one we are deleting a comment
-	//		if len(c.serverHub.rooms[c.roomName].comments.getRequestWithComments(message.Data).Comments) > len(message.BurpRequestResponse.Comments) {
-	//			/*
-	//				oldComments : A, B
-	//				newComments: A
-	//			*/
-	//			log.Println("Deleting Comments")
-	//			if len(c.serverHub.rooms[c.roomName].comments.getRequestWithComments(message.Data).Comments) > 1 {
-	//				for _, oldComment := range c.serverHub.rooms[c.roomName].comments.getRequestWithComments(message.Data).Comments {
-	//					for _, newComment := range message.BurpRequestResponse.Comments {
-	//						if oldComment != newComment {
-	//							if oldComment.UserWhoCommented == c.name {
-	//								c.serverHub.rooms[c.roomName].updateRequestResponseComments(message)
-	//							} else {
-	//								log.Printf("User " + c.name + " cannot delete comment by " + oldComment.UserWhoCommented)
-	//							}
-	//						}
-	//					}
-	//				}
-	//			} else {
-	//				//if the last comment for the request is authored by the sender they can delete it
-	//				if c.serverHub.rooms[c.roomName].comments.getRequestWithComments(message.Data).Comments[0].UserWhoCommented == c.name {
-	//					c.serverHub.rooms[c.roomName].updateRequestResponseComments(message)
-	//				} else {
-	//					log.Printf("User " + c.name + " cannot delete comment by another user")
-	//				}
-	//			}
-	//		} else {
-	//			//If the incoming request with comments has more comments than the old one we are adding a comment
-	//			/*
-	//				oldComments : A
-	//				newComments: A, B
-	//			*/
-	//			log.Println("Adding Comments")
-	//			for _, oldComment := range c.serverHub.rooms[c.roomName].comments.getRequestWithComments(message.Data).Comments {
-	//				for _, newComment := range message.BurpRequestResponse.Comments {
-	//					if oldComment != newComment {
-	//						if newComment.UserWhoCommented == c.name {
-	//							c.serverHub.rooms[c.roomName].updateRequestResponseComments(message)
-	//						} else {
-	//							log.Printf("User " + c.name + " cannot add comment by " + newComment.UserWhoCommented)
-	//						}
-	//					}
-	//				}
-	//			}
-	//		}
-	//	} else {
-	//		c.serverHub.rooms[c.roomName].updateRequestResponseComments(message)
-	//	}
-	case "GET_CONFIG_MESSAGE":
-		message.MessageType = "GET_CONFIG_MESSAGE"
-		if c.serverHub.shortenerService != nil {
-			message.Data = c.serverHub.shortenerService.apiKey
-		}
-		c.serverHub.messages <- generateMessage(message, c, c.roomName, message.MessageTarget)
-	case "COOKIE_MESSAGE":
-		fallthrough
-	case "SCAN_ISSUE_MESSAGE":
-		fallthrough
-	case "REPEATER_MESSAGE":
-		fallthrough
-	case "INTRUDER_MESSAGE":
-		fallthrough
-	case "BURP_MESSAGE":
-		c.serverHub.messages <- generateMessage(message, c, c.roomName, message.MessageTarget)
-	default:
-		return errors.New("ERROR: unknown message type")
-	}
-	return nil
-}
-
 func (c *Client) Reader() {
 	defer func() {
-		log.Println("Client leaving")
-		close(c.sendChannel)
-		c.serverHub.RemoveClient(c)
+		hub.unregister <- c
 		_ = c.conn.Close()
 	}()
-	_ = c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	if err := c.conn.SetReadDeadline(time.Now().Add(60 * time.Second)); err != nil {
+		log.Println("connection error:", err)
+	}
 	c.conn.SetPongHandler(func(string) error { _ = c.conn.SetReadDeadline(time.Now().Add(60 * time.Second)); return nil })
 	for {
 		_, message, err := c.conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				log.Printf("error: %v", err)
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				log.Printf("read error: %v from client: %s", err, c.name)
 			}
 			break
 		}
@@ -217,9 +52,10 @@ func (c *Client) Reader() {
 		if err := json.Unmarshal(bytes.Trim(decodedBytes, "\x00"), &newBurpMessage); err != nil {
 			log.Printf("Could not unmarshal BurpTCMessage, error: %s \n", err)
 		} else {
-			if err = c.parseMessage(newBurpMessage); err != nil {
-				log.Printf("Could not parse BurpTCMessage, error: %s \n", err)
-
+			hub.messages <- &Message{
+				msg:      newBurpMessage,
+				sender:   c,
+				roomName: c.room,
 			}
 		}
 	}
@@ -229,35 +65,38 @@ func (c *Client) Writer() {
 	ticker := time.NewTicker(50 * time.Second)
 	defer func() {
 		ticker.Stop()
-		_ = c.conn.Close()
+		if c.conn != nil {
+			_ = c.conn.Close()
+		}
 	}()
 	for {
 		select {
 		case message, ok := <-c.sendChannel:
 			if c.conn != nil {
-				_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 				if !ok {
-					// The hub closed the channel.
-					if err := c.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
-						log.Println(err)
+					log.Printf("Client %s is Not okay", c.name)
+					//if err := c.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
+					//	log.Println("Error sending close message: ", err)
+					//}
+					return
+				}
+
+				_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+
+				if jsonBytes, err := json.Marshal(message.msg); err == nil {
+
+					encodedBuf := make([]byte, base64.StdEncoding.EncodedLen(len(jsonBytes)))
+					base64.StdEncoding.Encode(encodedBuf, jsonBytes)
+					if err := c.conn.WriteMessage(websocket.TextMessage, encodedBuf); err != nil {
+						log.Printf("Error Writing message: %s", err)
+						return
 					}
 
-					return
+				} else {
+					log.Println("Error marshalling json message: ", err)
 				}
-
-				w, err := c.conn.NextWriter(websocket.TextMessage)
-				if err != nil {
-					return
-				}
-				jsonBytes, err := json.Marshal(message.msg)
-				encodedBuf := make([]byte, base64.StdEncoding.EncodedLen(len(jsonBytes)))
-				base64.StdEncoding.Encode(encodedBuf, jsonBytes)
-				if _, err := w.Write(encodedBuf); err != nil {
-					log.Printf("Error Writing message: %s\n", err)
-				}
-				if err := w.Close(); err != nil {
-					return
-				}
+			} else {
+				return
 			}
 		case <-ticker.C:
 			_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))

--- a/internal/Message.go
+++ b/internal/Message.go
@@ -4,5 +4,4 @@ type Message struct {
 	msg      *BurpTCMessage
 	sender   *Client
 	roomName string
-	target   string
 }

--- a/internal/Room.go
+++ b/internal/Room.go
@@ -1,118 +1,17 @@
 package internal
 
-import (
-	"encoding/json"
-	"log"
-	"strings"
-	"sync"
-)
-
 type Room struct {
-	scope   string
-	clients map[string]*Client
-	*sync.RWMutex
-	comments  Comments
-	password  string
-	serverHub *ServerHub
-	name      string
+	scope    string
+	name     string
+	password string
+	clients  map[string]*Client
 }
 
-func NewRoom(serverHub *ServerHub, password string, roomName string) *Room {
+func NewRoom(roomName string, password string) *Room {
 	return &Room{
 		"",
-		make(map[string]*Client),
-		new(sync.RWMutex),
-		NewComments(),
-		password,
-		serverHub,
 		roomName,
-	}
-}
-
-func (r *Room) getAllComments() Comments {
-	return r.comments
-}
-
-func (r *Room) getClient(clientName string) (*Client, bool) {
-	r.Lock()
-	defer r.Unlock()
-	if client, ok := r.clients[clientName]; ok {
-		return client, ok
-	}
-	return nil, false
-}
-
-func (r *Room) addClient(c *Client) {
-	r.Lock()
-	r.clients[c.name] = c
-	c.roomName = r.name
-	r.Unlock()
-	r.updateRoomMembers()
-}
-
-func (r *Room) deleteClient(clientName string) {
-	r.Lock()
-	if _, ok := r.clients[clientName]; ok {
-		delete(r.clients, clientName)
-	}
-	r.Unlock()
-	r.updateRoomMembers()
-
-}
-
-func (r *Room) updateRoomMembers() {
-	if r.name == "server" {
-		return
-	}
-	msg := NewBurpTCMessage()
-	msg.MessageType = "NEW_MEMBER_MESSAGE"
-
-	r.Lock()
-	keys := make([]string, 0, len(r.clients))
-	for k := range r.clients {
-		keys = append(keys, k)
-	}
-	r.Unlock()
-	if len(keys) > 0 {
-		msg.Data = strings.Join(keys, ",")
-		log.Printf("Current room (%s) members: %s", r.name, msg.Data)
-		r.serverHub.messages <- generateMessage(msg, nil, r.name, "Room")
-	} else {
-		log.Println("no room members to update")
-	}
-
-}
-
-func (r *Room) updateRequestResponseComments(tcMessage *BurpTCMessage) {
-	log.Printf("Got comment message: " + tcMessage.String())
-	r.comments.setRequestWithComments(tcMessage.Data, *tcMessage.BurpRequestResponse)
-	log.Printf("%d comments in room", len(r.comments.requestsWithComments))
-	r.serverHub.messages <- generateMessage(tcMessage, nil, r.name, tcMessage.MessageTarget)
-}
-
-func (r *Room) sendRoomMessagesToNewRoomMember(clientName string) {
-	if len(r.comments.requestsWithComments) != 0 {
-		r.Lock()
-		defer r.Unlock()
-		client := r.clients[clientName]
-		msg := NewBurpTCMessage()
-		msg.MessageType = "GET_COMMENTS_MESSAGE"
-
-		burpMessagesWithComments := make([]BurpRequestResponse, len(r.comments.requestsWithComments))
-		idx := 0
-		for _, value := range r.comments.requestsWithComments {
-			burpMessagesWithComments[idx] = value
-			log.Printf(value.String())
-			idx++
-		}
-
-		log.Printf("Sending %d current room messages to %s", len(burpMessagesWithComments), clientName)
-		jsonData, err := json.Marshal(burpMessagesWithComments)
-		if err != nil {
-			log.Println(err)
-		} else {
-			msg.Data = string(jsonData)
-			r.serverHub.messages <- generateMessage(msg, client, r.name, "Self")
-		}
+		password,
+		make(map[string]*Client),
 	}
 }

--- a/internal/ServerHub.go
+++ b/internal/ServerHub.go
@@ -1,152 +1,285 @@
 package internal
 
 import (
+	"errors"
+	"fmt"
 	"github.com/fasthttp/websocket"
 	"log"
 	"strconv"
 	"strings"
-	"sync"
 )
 
-type ServerHub struct {
-	mu               sync.Mutex
-	allClients       map[string]*Client
+var hub *Hub
+
+type Hub struct {
 	rooms            map[string]*Room
-	messages         chan Message
+	messages         chan *Message
+	register         chan *Client
+	unregister       chan *Client
 	serverPassword   string
 	shortenerService *ShortenedUrls
 }
 
-func NewServerHub(serverPassword string) *ServerHub {
-	serverHub := &ServerHub{
-		allClients:     make(map[string]*Client),
+func NewHub(serverPassword string) *Hub {
+	hub := &Hub{
+		register:       make(chan *Client),
+		unregister:     make(chan *Client),
 		rooms:          make(map[string]*Room),
-		messages:       make(chan Message),
+		messages:       make(chan *Message, 1024),
 		serverPassword: serverPassword,
 	}
 
-	serverHub.rooms["server"] = NewRoom(serverHub, "", "server")
-	go serverHub.eventLoop()
+	//initialize server lobby room
+	hub.rooms["server"] = NewRoom("server", "")
 
-	return serverHub
+	go hub.eventLoop()
+
+	return hub
 }
 
-func (serverHub *ServerHub) GetClientByName(clientName string) *Client {
-	return serverHub.allClients[clientName]
-}
-
-func (serverHub *ServerHub) SetShortenerService(shortenerService *ShortenedUrls) {
-	serverHub.shortenerService = shortenerService
-}
-
-func (serverHub *ServerHub) eventLoop() {
-
-	for message := range serverHub.messages {
-		room := serverHub.rooms[message.roomName]
-		if message.target == "Self" { //echo message to client who sent it
-			message.sender.sendChannel <- message
-		} else if message.target == "Room" { //to everyone in the room
-			if message.sender != nil {
-				//sent from user to other room members
-				for name, client := range room.clients {
-					if name != message.sender.name {
-						log.Printf("has client %v+ muted us? %t", client, room.clients[name].isGivenClientMuted(message.sender.name))
-						if !room.clients[name].isGivenClientMuted(message.sender.name) {
-							serverHub.sendMessage(client, message, room)
-						}
+func (h *Hub) eventLoop() {
+	for {
+		select {
+		case newSubscription := <-h.register:
+			log.Printf("Registering new client %v", newSubscription)
+			//when registering we add them to the server lobby default room
+			h.rooms["server"].clients[newSubscription.name] = newSubscription
+		case leavingSubscription := <-h.unregister:
+			log.Printf("Client %v is leaving", leavingSubscription)
+			//get current room members
+			currentRoomMembers := h.rooms[leavingSubscription.room]
+			//if the room exists
+			if currentRoomMembers != nil {
+				//if the current room members includes the leaving client
+				if _, ok := currentRoomMembers.clients[leavingSubscription.name]; ok {
+					//remove the client from the room
+					delete(currentRoomMembers.clients, leavingSubscription.name)
+					//close the clients send channel so no more messages are sent to them
+					close(leavingSubscription.sendChannel)
+					//if the room has no more members and isn't the server lobby, delete the room
+					if len(currentRoomMembers.clients) == 0 && currentRoomMembers.name != "server" {
+						delete(h.rooms, currentRoomMembers.name)
+					} else {
+						h.updateRoomMembers(currentRoomMembers.name)
 					}
 				}
-			} else {
-				//sent from server to room
-				for _, client := range room.clients {
-					serverHub.sendMessage(client, message, room)
-				}
 			}
-		} else { //to a specific person
-			if !room.clients[message.target].isGivenClientMuted(message.sender.name) {
-				clientToMessage, exists := room.getClient(message.target)
-				if exists && !clientToMessage.isGivenClientMuted(message.sender.name) {
-					serverHub.sendMessage(clientToMessage, message, room)
-				}
+		case message := <-h.messages:
+			if err := h.parseMessage(message); err != nil {
+				log.Printf("Error parsing message: %s", err)
 			}
 		}
 	}
 }
 
-func (serverHub *ServerHub) sendMessage(clientToMessage *Client, message Message, room *Room) {
+func (h *Hub) sendMessageToClient(message *Message) {
 	select {
-	case clientToMessage.sendChannel <- message:
+	case message.sender.sendChannel <- message:
+		log.Printf("Sent message %v to client %s", message, message.sender.name)
 	default:
-		close(clientToMessage.sendChannel)
-		delete(room.clients, clientToMessage.name)
-		if len(room.clients) == 0 {
-			serverHub.deleteRoom(message.roomName)
+		h.unregister <- message.sender
+	}
+}
+
+func (h *Hub) sendMessageToRoom(message *Message) {
+
+	for _, roomMember := range h.rooms[message.roomName].clients {
+		if message.sender != nil && roomMember.name != message.sender.name {
+			if !roomMember.isGivenClientMuted(message.sender.name) {
+				select {
+				case roomMember.sendChannel <- message:
+					log.Printf("Sent message %v to client %s", message, roomMember.name)
+				default:
+					h.unregister <- roomMember
+				}
+			}
 		}
 	}
 }
 
-func (serverHub *ServerHub) deleteRoom(roomName string) {
-	if roomName != "server" {
-		log.Printf("Room %s is empty. Deleting", roomName)
-		delete(serverHub.rooms, roomName)
+func (h *Hub) Register(conn *websocket.Conn, clientName string) *Client {
+	userNumber, err := generateRandomUserNumber()
+	if err != nil {
+		log.Fatalln("Why are we not generating random numbers")
 	}
-	serverHub.updateRooms()
-}
-
-func (serverHub *ServerHub) updateRooms() {
-	msg := NewBurpTCMessage()
-	msg.MessageType = "GET_ROOMS_MESSAGE"
-
-	keys := make([]string, 0, len(serverHub.rooms))
-	for k := range serverHub.rooms {
-		if k != "server" {
-			keys = append(keys, k+"::"+strconv.FormatBool(len(serverHub.rooms[k].password) > 0))
-		}
+	client := &Client{
+		conn:         conn,
+		room:         "server",
+		name:         fmt.Sprintf("%s#%d", clientName, userNumber),
+		mutedClients: []string{},
+		sendChannel:  make(chan *Message, 1024),
 	}
-	log.Printf("Current rooms: %s", strings.Join(keys, ","))
-	msg.Data = strings.Join(keys, ",")
-	serverHub.messages <- generateMessage(msg, nil, "server", "Room")
-}
 
-func (serverHub *ServerHub) ClientExistsInServer(clientName string) bool {
-	serverHub.mu.Lock()
-	defer serverHub.mu.Unlock()
-	for name := range serverHub.allClients {
-		if name == clientName {
-			return true
-		}
-	}
-	return false
-}
-
-func (serverHub *ServerHub) Register(conn *websocket.Conn, clientName string) *Client {
-	client := &Client{serverHub: serverHub, conn: conn,
-		name: clientName, roomName: "server", mutedClients: []string{}, sendChannel: make(chan Message, 1024)}
-
-	serverHub.mu.Lock()
-	{
-		serverHub.allClients[clientName] = client
-		serverHub.rooms["server"].addClient(client)
-	}
-	serverHub.mu.Unlock()
+	h.register <- client
 
 	return client
 }
 
-func (serverHub *ServerHub) RemoveClient(client *Client) {
-	serverHub.mu.Lock()
-	delete(serverHub.allClients, client.name)
-	serverHub.rooms[client.roomName].deleteClient(client.name)
-	if client.roomName != "server" && len(serverHub.rooms[client.roomName].clients) == 0 {
-		serverHub.deleteRoom(client.roomName)
-	}
+func (h *Hub) parseMessage(message *Message) error {
+	log.Printf("Got message type: %s from client: %v to room %s", message.msg.MessageType, message.sender, message.roomName)
+	switch message.msg.MessageType {
+	case "NEW_MEMBER_MESSAGE":
+		if h.rooms[message.roomName].clients != nil {
+			for _, roomMember := range h.rooms[message.roomName].clients {
+				log.Printf("Sending message type %s to client %s", message.msg.MessageType, roomMember.name)
+				select {
+				case roomMember.sendChannel <- message:
+				default:
+					h.unregister <- roomMember
+				}
+			}
+		}
+	case "SET_SCOPE_MESSAGE":
+		log.Printf("received new scope from %s", message.sender.name)
+		h.rooms[message.sender.room].scope = message.msg.Data
+	case "GET_SCOPE_MESSAGE":
+		log.Printf("%s requesting scope", message.sender.name)
+		message.msg.Data = h.rooms[message.sender.room].scope
+		h.sendMessageToClient(message)
+	case "JOIN_ROOM_MESSAGE":
+		roomTargetData := strings.Split(message.msg.Data, ":")
+		roomServerPassword := h.rooms[roomTargetData[0]].password
+		if len(roomServerPassword) > 0 {
+			if roomServerPassword == roomTargetData[1] {
+				h.clientRoomChangeHandler(message.sender, roomTargetData[0])
+				//change response message type so client knows auth succeeded
+				message.msg.MessageType = "GOOD_PASSWORD_MESSAGE"
+				//send to client
+				h.sendMessageToClient(message)
+			} else {
+				//bad password
+				message.msg.MessageType = "BAD_PASSWORD_MESSAGE"
+				h.sendMessageToClient(message)
+			}
+		} else {
+			h.clientRoomChangeHandler(message.sender, roomTargetData[0])
+		}
+	case "LEAVE_ROOM_MESSAGE":
+		log.Printf("%s leaving room: %s", message.sender.name, message.sender.room)
+		h.clientRoomChangeHandler(message.sender, "server")
+	case "ADD_ROOM_MESSAGE":
+		roomTargetData := strings.Split(message.msg.Data, ":")
+		log.Printf("creating new room: %s with password : %s", roomTargetData[0], roomTargetData[1])
+		if _, ok := h.rooms[roomTargetData[0]]; ok {
+			message.msg.MessageType = "ROOM_EXISTS_MESSAGE"
+			h.sendMessageToClient(message)
+		} else {
+			if len(roomTargetData) > 1 {
+				h.rooms[roomTargetData[0]] = NewRoom(roomTargetData[0], roomTargetData[1])
+			} else {
+				h.rooms[roomTargetData[0]] = NewRoom(roomTargetData[0], "")
+			}
+			h.clientRoomChangeHandler(message.sender, roomTargetData[0])
+			h.announceNewRooms()
+		}
+	case "MUTE_MESSAGE":
+		if message.msg.Data == "All" {
+			for _, roomMember := range h.rooms[message.sender.room].clients {
+				if roomMember.name != message.sender.name {
+					message.sender.mutedClients = append(message.sender.mutedClients, roomMember.name)
+				}
+			}
+		} else {
+			if message.msg.Data != message.sender.name {
+				message.sender.mutedClients = append(message.sender.mutedClients, message.msg.Data)
+			}
+		}
+		log.Printf("%s muted these clients %s", message.sender.name, message.sender.mutedClients)
+	case "UNMUTE_MESSAGE":
+		if message.msg.Data == "All" {
+			for _, roomMember := range h.rooms[message.sender.room].clients {
+				if roomMember.name != message.sender.name {
+					message.sender.mutedClients = remove(message.sender.mutedClients, index(message.sender.mutedClients, roomMember.name))
+				}
+			}
+		} else {
+			if message.msg.Data != message.sender.name {
+				message.sender.mutedClients = remove(message.sender.mutedClients, index(message.sender.mutedClients, message.msg.Data))
+			}
+		}
+		log.Printf("%s unmuted %s", message.sender.name, message.msg.Data)
+	case "GET_ROOMS_MESSAGE":
 
-	serverHub.mu.Unlock()
+		rooms := h.rooms
+		keys := make([]string, 0, len(rooms))
+		for k := range rooms {
+			if k != "server" {
+				keys = append(keys, k+"::"+strconv.FormatBool(len(rooms[k].password) > 0))
+			}
+		}
+		message.msg.Data = strings.Join(keys, ",")
+
+		if message.sender == nil {
+			//server announcing new rooms to lobby
+			for _, lobbyMember := range h.rooms["server"].clients {
+				lobbyMember.sendChannel <- message
+			}
+		} else {
+			h.sendMessageToClient(message)
+		}
+	case "GET_CONFIG_MESSAGE":
+		if h.shortenerService != nil {
+			message.msg.Data = h.shortenerService.apiKey
+		}
+		h.sendMessageToClient(message)
+	case "COOKIE_MESSAGE":
+		fallthrough
+	case "SCAN_ISSUE_MESSAGE":
+		fallthrough
+	case "REPEATER_MESSAGE":
+		fallthrough
+	case "INTRUDER_MESSAGE":
+		fallthrough
+	case "BURP_MESSAGE":
+		h.sendMessageToRoom(message)
+	default:
+		return errors.New("ERROR: unknown message type")
+	}
+	return nil
 }
 
-func (serverHub *ServerHub) addRoom(roomPassword string, roomName string) {
-	serverHub.mu.Lock()
-	defer serverHub.mu.Unlock()
-	serverHub.rooms[roomName] = NewRoom(serverHub, roomPassword, roomName)
-	serverHub.updateRooms()
+func (h *Hub) announceNewRooms() {
+	msg := NewBurpTCMessage()
+	msg.MessageType = "GET_ROOMS_MESSAGE"
+	h.messages <- generateMessage(msg, nil, "server")
+}
+
+func (h *Hub) updateRoomMembers(roomName string) {
+	if roomName == "server" {
+		return
+	}
+	msg := NewBurpTCMessage()
+	msg.MessageType = "NEW_MEMBER_MESSAGE"
+
+	keys := make([]string, 0, len(h.rooms[roomName].clients))
+	for k := range h.rooms[roomName].clients {
+		keys = append(keys, k)
+	}
+
+	if len(keys) > 0 {
+		msg.Data = strings.Join(keys, ",")
+		log.Printf("Current room (%s) members: %s", roomName, msg.Data)
+		h.messages <- generateMessage(msg, nil, roomName)
+	} else {
+		log.Println("no room members to update")
+		delete(h.rooms, roomName)
+	}
+
+}
+
+func (h *Hub) clientRoomChangeHandler(clientChangingRooms *Client, newRoom string) {
+	log.Printf("%s joining room: %s", clientChangingRooms.name, newRoom)
+	//remove client from previous room
+	delete(h.rooms[clientChangingRooms.room].clients, clientChangingRooms.name)
+	//notify remaining room clients of leaving member
+	h.updateRoomMembers(clientChangingRooms.room)
+	//add them to the new room
+	clientChangingRooms.room = newRoom
+	h.rooms[newRoom].clients[clientChangingRooms.name] = clientChangingRooms
+	//notify current room clients of new member
+	h.updateRoomMembers(newRoom)
+}
+
+func (h *Hub) SetShortenerService(shortenerService *ShortenedUrls) {
+	h.shortenerService = shortenerService
 }

--- a/internal/Utils.go
+++ b/internal/Utils.go
@@ -1,5 +1,11 @@
 package internal
 
+import (
+	"crypto/rand"
+	"math"
+	"math/big"
+)
+
 func remove(s []string, i int) []string {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]
@@ -15,11 +21,32 @@ func index(vs []string, t string) int {
 	return -1
 }
 
-func generateMessage(burpTCMessage *BurpTCMessage, sender *Client, roomName string, target string) Message {
-	return Message{
+func generateRandomUserNumber() (int, error) {
+	maxLimit := int64(int(math.Pow10(5)) - 1)
+	lowLimit := int(math.Pow10(5 - 1))
+
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(maxLimit))
+	if err != nil {
+		return 0, err
+	}
+	randomNumberInt := int(randomNumber.Int64())
+
+	// Handling integers between 0, 10^(n-1) .. for n=4, handling cases between (0, 999)
+	if randomNumberInt <= lowLimit {
+		randomNumberInt += lowLimit
+	}
+
+	// Never likely to occur, kust for safe side.
+	if randomNumberInt > int(maxLimit) {
+		randomNumberInt = int(maxLimit)
+	}
+	return randomNumberInt, nil
+}
+
+func generateMessage(burpTCMessage *BurpTCMessage, sender *Client, roomName string) *Message {
+	return &Message{
 		msg:      burpTCMessage,
 		sender:   sender,
 		roomName: roomName,
-		target:   target,
 	}
 }


### PR DESCRIPTION
Removed MessageTarget from the server messages. This was superfluous and actually could have lead to a vuln where users could send messages to a room they were not in. 
Moved processing of messages to the server process instead of client goroutines. This removes the need for locks on server information like room members and such. 
Users are given a numeric suffix to avoid needing to check for duplicate names. 
Room names are now checked for uniqueness.